### PR TITLE
Changed keep_dims (deprecated) to keepdims and added num=4 to tf.unstack

### DIFF
--- a/tfquaternion/tfquaternion.py
+++ b/tfquaternion/tfquaternion.py
@@ -386,7 +386,7 @@ class Quaternion(object):
     @scope_wrapper
     def norm(self, keepdims=True):
         """Return the norm of the quaternion."""
-        return tf.reduce_sum(tf.square(self._q), axis=-1, keep_dims=keepdims)
+        return tf.reduce_sum(tf.square(self._q), axis=-1, keepdims=keepdims)
 
     @scope_wrapper
     def abs(self, keepdims=True):

--- a/tfquaternion/tfquaternion.py
+++ b/tfquaternion/tfquaternion.py
@@ -90,8 +90,8 @@ def quaternion_multiply(a, b):
     """
     a = _prepare_tensor_for_div_mul(a)
     b = _prepare_tensor_for_div_mul(b)
-    w1, x1, y1, z1 = tf.unstack(a, axis=-1)
-    w2, x2, y2, z2 = tf.unstack(b, axis=-1)
+    w1, x1, y1, z1 = tf.unstack(a, axis=-1, num=4)
+    w2, x2, y2, z2 = tf.unstack(b, axis=-1, num=4)
     w = w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2
     x = w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2
     y = w1 * y2 + y1 * w2 + z1 * x2 - x1 * z2
@@ -114,8 +114,8 @@ def quaternion_divide(a, b):
     if a.shape == () or a.shape[-1] == 1:  # scalar
         return Quaternion(tf.multiply(a, b.conj()) / Quaternion(b).norm())
     bnorm = tf.squeeze(Quaternion(b).norm())
-    w1, x1, y1, z1 = tf.unstack(a, axis=-1)
-    w2, x2, y2, z2 = tf.unstack(b, axis=-1)
+    w1, x1, y1, z1 = tf.unstack(a, axis=-1, num=4)
+    w2, x2, y2, z2 = tf.unstack(b, axis=-1, num=4)
     w = (w1 * w2 + x1 * x2 + y1 * y2 + z1 * z2) / bnorm
     x = (-w1 * x2 + x1 * w2 - y1 * z2 + z1 * y2) / bnorm
     y = (-w1 * y2 + x1 * z2 + y1 * w2 - z1 * x2) / bnorm


### PR DESCRIPTION
Updated keep_dims, which is deprecated, to keepdims instead.

Added num=4 to tf.unstack to handle cases where num can not be automatically inferred.
I encountered such a case and it never hurts to pass known parameters instead of relying on automatic inference.